### PR TITLE
ci: bump GitHub Actions to current majors for Node.js 24 deadline

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,16 +25,16 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v5
         with:
           files: lcov.info
           fail_ci_if_error: true  # This will make CI fail if Codecov upload fails
@@ -42,8 +42,8 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - uses: julia-actions/julia-buildpkg@v1


### PR DESCRIPTION
## Summary
GitHub is enforcing Node.js 24 on all Actions runners on **June 2, 2026** and removing Node.js 20 entirely on **September 16, 2026**. Several actions in `.github/workflows/CI.yml` were pinned to majors that ship Node 16/20 entrypoints and will break.

This bumps action versions to the current stable majors:

- `actions/checkout`: `v2` / `v3` → `v4`
- `julia-actions/setup-julia`: `v1` → `v2`
- `julia-actions/cache`: `v1` → `v2`
- `codecov/codecov-action`: `v3` → `v5`

`julia-actions/julia-buildpkg`, `julia-runtest`, `julia-processcoverage`, and `julia-docdeploy` remain at `@v1` — `v1` is still the current major and the maintainers update the floating tag for runtime compatibility. `TagBot.yml` (`JuliaRegistries/TagBot@v1`) and `CompatHelper.yml` (no actions, only inline `julia -e`) are unchanged.

No other workflow logic touched — version bumps only.

## Test plan
- [ ] CI run on this PR completes green on Julia 1.9 + nightly
- [ ] Docs job builds and deploys without warnings about deprecated Node versions
- [ ] Codecov upload succeeds with v5 action (no breaking changes expected for `files` + `fail_ci_if_error` inputs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)